### PR TITLE
Jc/event controllers v2

### DIFF
--- a/backend/controllers/event.controller.ts
+++ b/backend/controllers/event.controller.ts
@@ -1,11 +1,275 @@
+import { AppPermissionName, Event, EventStatus } from "@prisma/client";
+import {
+  CursorPaginationDatetimeParams,
+  CursorPaginationDatetimeSchema,
+  EventCreateSchema,
+  EventUpdateSchema,
+  IdParamSchema,
+} from "../../shared/zodSchemas";
 import { NextFunction, Request, Response } from "express";
-import { IdParamSchema } from "../../shared/zodSchemas";
 import prisma from "../prisma/client"; // import the singleton prisma instance
 import { AppError, AppErrorName } from "../utils/AppError";
+import { checkUserPermission } from "../utils/checkUserPermission";
+
+const userId = 3; // Placeholder for testing
 
 // test Event
 export const eventTest = async (req: Request, res: Response) => {
   res.status(200).json({ message: "Event endpoint works" });
+};
+
+// Create new Event
+// Takes multipart form data.
+// The user is required to have CREATE_EVENTS permission for the organization
+export const createVerifiedEvent = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    // Get userId
+    // const userId = req.user.id; // get userId from the request -> should set in auth middleware
+    // Validate request id param
+    const organizationId = IdParamSchema.parse(req.params).id;
+
+    // Validate the Event data with zod schema
+    const validatedEventData = EventCreateSchema.parse(req.body);
+    let newEvent: Event;
+
+    // check if the user has permission to create an event
+    const hasPermission = await checkUserPermission(
+      userId,
+      organizationId,
+      AppPermissionName.CREATE_EVENTS,
+    );
+    if (hasPermission) {
+      // Create a verified event for an organization
+      newEvent = await prisma.event.create({
+        data: {
+          ...validatedEventData,
+          organizationId,
+          userId,
+          status: EventStatus.Verified,
+        },
+      });
+
+      // TODO: Upload image
+      if (req.file) {
+        // const uniqueFileName = generateUniqueFileName(req.file.originalname);
+        // // idk maybe make the path something like:
+        // // images/events/<eventId>-<timestamp>_<originalname>
+        // // images/events/123_2024-01-16T12-34-56.789Z_example.png
+        // const path = `images/events/${newEvent.id}_${uniqueFileName}`;
+        // await UploadToS3(req.file, path);
+        // // console.log("File uploaded successfully");
+        // // update event record with image path
+        // newEvent = await prisma.event.update({
+        //   where: { id: newEvent.id },
+        //   data: {
+        //     image: path,
+        //   },
+        // });
+      }
+    } else {
+      throw new AppError(
+        AppErrorName.PERMISSION_ERROR,
+        `User does not have permission to create event`,
+        403,
+        true,
+      );
+    }
+
+    if (newEvent) {
+      // Event created successfully
+      res.status(201).json({
+        message: "Event created successfully",
+        data: newEvent,
+      });
+    } else {
+      // Throw an error if the event creation returned an empty result
+      throw new AppError(
+        AppErrorName.EMPTY_RESULT_ERROR,
+        "Event creation returned empty result.",
+        500,
+        true,
+      );
+    }
+  } catch (error: any) {
+    // hand error over to error handling middleware
+    next(error);
+  }
+};
+
+// Create new Event
+export const createEvent = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    // Get userId
+    // const userId = req.user.id; // get userId from the request -> set in auth middleware
+
+    // Validate the Event data
+    const validatedEventData = EventCreateSchema.parse(req.body);
+
+    // create event
+    const newEvent = await prisma.event.create({
+      data: {
+        ...validatedEventData,
+        userId,
+        status: EventStatus.NonVerified,
+      },
+    });
+
+    // TODO: Upload image
+    if (req.file) {
+      // const uniqueFileName = generateUniqueFileName(req.file.originalname);
+      // // idk maybe make the path something like:
+      // // images/events/<eventId>-<timestamp>_<originalname>
+      // // images/events/123_2024-01-16T12-34-56.789Z_example.png
+      // const path = `images/events/${newEvent.id}_${uniqueFileName}`;
+      // await UploadToS3(req.file, path);
+      // // console.log("File uploaded successfully");
+      // // update event record with image path
+      // newEvent = await prisma.event.update({
+      //   where: { id: newEvent.id },
+      //   data: {
+      //     image: path,
+      //   },
+      // });
+    }
+
+    if (newEvent) {
+      // Event created successfully
+      res.status(201).json({
+        message: "Event created successfully",
+        data: newEvent,
+      });
+    } else {
+      // Throw an error if the event creation returned an empty result
+      throw new AppError(
+        AppErrorName.EMPTY_RESULT_ERROR,
+        "Event creation returned empty result.",
+        500,
+        true,
+      );
+    }
+  } catch (error: any) {
+    // hand error over to error handling middleware
+    next(error);
+  }
+};
+
+// Update Event
+export const updateEvent = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    // Validate request id param
+    const eventId = IdParamSchema.parse(req.params).id;
+    // const userId = req.userId; // get userId from the request
+
+    // Validate event data
+    const validatedUpdateEventData = EventUpdateSchema.parse(req.body);
+
+    // get the event from the database
+    const existingEvent = await prisma.event.findUnique({
+      where: {
+        id: eventId,
+      },
+    });
+    if (!existingEvent) {
+      throw new AppError(
+        AppErrorName.NOT_FOUND_ERROR,
+        `Event with id ${eventId} not found`,
+        404,
+        true,
+      );
+    }
+
+    // Check if the user has permission to update the event details
+    const isCreatedByUser: boolean = existingEvent.userId === userId;
+    let hasPermission: boolean = false;
+
+    // Check if there is a group associated with the event data
+    if (existingEvent.organizationId) {
+      // check if the user has permission to update the event
+      hasPermission = await checkUserPermission(
+        userId,
+        existingEvent.organizationId,
+        AppPermissionName.MANAGE_EVENTS,
+      );
+    }
+
+    let updatedEvent: Event;
+    if (hasPermission || isCreatedByUser) {
+      // TODO: Upload image
+      if (req.file) {
+        // const uniqueFileName = generateUniqueFileName(req.file.originalname);
+        // const path = `images/events/${existingEvent.id}_${uniqueFileName}`;
+        // await UploadToS3(req.file, path);
+        // // console.log("File uploaded successfully");
+        // validatedUpdateEventData.image = path;
+      }
+
+      // Update the event
+      updatedEvent = await prisma.event.update({
+        where: { id: eventId },
+        data: {
+          ...validatedUpdateEventData,
+        },
+      });
+      // send back the updated event
+      if (updatedEvent) {
+        // Event created successfully
+        res.status(200).json({
+          message: "Event updated successfully",
+          data: updatedEvent,
+        });
+      }
+    } else {
+      throw new AppError(
+        AppErrorName.PERMISSION_ERROR,
+        `User does not have permission to update event`,
+        403,
+        true,
+      );
+    }
+  } catch (error: any) {
+    next(error);
+  }
+};
+
+// Get all Events
+export const getAllEvents = async (req: Request, res: Response) => {
+  try {
+    const allEvents = await prisma.event.findMany();
+    res.status(200).json(allEvents);
+  } catch (error) {
+    console.error("Error fetching events:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+};
+
+// Get all verified events
+export const getAllVerifiedEvents = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const allEvents = await prisma.event.findMany({
+      where: {
+        status: EventStatus.Verified,
+      },
+    });
+    res.status(200).json(allEvents);
+  } catch (error) {
+    next(error);
+  }
 };
 
 // Get Event by Id
@@ -39,6 +303,164 @@ export const getEventById = async (
 
     res.status(200).json(event);
   } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Retrieves the most recent events using cursor pagination based on timestamp.
+ *
+ * @param req - The Express request object containing query parameters.
+ * @param res - The Express response object for sending the result.
+ * @param next - The Express next function for error handling.
+ *
+ * @returns {Promise<void>} A JSON response containing recent events and the cursor for the next page.
+ * @example
+ * First query, no cursor: `api/events/recent/?pageSize=10`
+ * Subsequent pages: `api/events/recent/?pageSize=10&cursor=2023-12-31T05:49:02.388Z`
+ */
+export const getRecentEvents = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    // Validate the cursor options from request query parameters
+    const validatedPaginationParams: CursorPaginationDatetimeParams =
+      CursorPaginationDatetimeSchema.parse(req.query);
+
+    let recentEvents;
+    if (!validatedPaginationParams.cursor) {
+      // First query, there is no pagination cursor to pass in
+      recentEvents = await prisma.event.findMany({
+        take: validatedPaginationParams.pageSize,
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }], // createdAt 'desc' to sort from newest to oldest
+      });
+    } else {
+      recentEvents = await prisma.event.findMany({
+        take: validatedPaginationParams.pageSize,
+        skip: 1, // skip the cursor
+        cursor: { createdAt: validatedPaginationParams.cursor },
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      });
+    }
+
+    // Extract the cursor for the next page
+    const nextCursor =
+      recentEvents.length > 0
+        ? recentEvents[recentEvents.length - 1].createdAt
+        : null;
+
+    res.status(200).json({
+      data: recentEvents,
+      cursor: nextCursor,
+    });
+  } catch (error: any) {
+    next(error);
+  }
+};
+
+// Get all events by organization
+export const getAllEventsByOrganization = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    // Validate request id param
+    const organizationId = IdParamSchema.parse(req.params).id;
+
+    // Get events from db
+    const allOrgEvents = await prisma.event.findMany({
+      where: {
+        organizationId: organizationId,
+      },
+    });
+
+    res.status(200).json(allOrgEvents);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Delete event
+export const deleteEvent = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    // Validate request id param
+    const eventId = IdParamSchema.parse(req.params).id;
+    // const userId = req.user.id;
+
+    // TODO: clean up and pull the code below into event.service
+    // get the event from the database
+    const existingEvent = await prisma.event.findUnique({
+      where: {
+        id: eventId,
+      },
+    });
+
+    if (!existingEvent) {
+      throw new AppError(
+        AppErrorName.NOT_FOUND_ERROR,
+        "Event not found",
+        404,
+        true,
+      );
+    }
+
+    // Check if the user is the event's creator
+    const isCreatedByUser: boolean = existingEvent.userId === userId;
+
+    // Check if there is a group associated with the event data
+    if (existingEvent.organizationId) {
+      // check if the user has permission to delete the event
+      const hasPermission = await checkUserPermission(
+        userId,
+        existingEvent.organizationId,
+        AppPermissionName.MANAGE_EVENTS,
+      );
+
+      // Check if the user has permission to manage events or if they are the event creator
+      if (hasPermission || isCreatedByUser) {
+        // Delete the event
+        await prisma.event.delete({
+          where: { id: eventId },
+        });
+      } else {
+        console.error(
+          `User with userId: ${userId} does not have permission to delete the event with eventId: ${eventId}`,
+        );
+
+        throw new AppError(
+          AppErrorName.PERMISSION_ERROR,
+          `User does not have permission to delete event`,
+          403,
+          true,
+        );
+      }
+      // Event not associated with an organization, check if user is the one who created the event
+    } else if (isCreatedByUser) {
+      // Delete the event
+      await prisma.event.delete({
+        where: { id: eventId },
+      });
+    } else {
+      console.error(
+        `User with userId: ${userId} does not have permission to delete the event with eventId: ${eventId}`,
+      );
+
+      throw new AppError(
+        AppErrorName.PERMISSION_ERROR,
+        `User does not have permission to delete event`,
+        403,
+        true,
+      );
+    }
+    res.status(204).end(); // No content after sucessful deletion
+  } catch (error: any) {
     next(error);
   }
 };

--- a/backend/controllers/org.controller.ts
+++ b/backend/controllers/org.controller.ts
@@ -1,0 +1,47 @@
+import { OrganizationCreateSchema } from "../../shared/zodSchemas";
+import { NextFunction, Request, Response } from "express";
+import { createOrganizationWithDefaults } from "../services/org.service";
+import { AppError, AppErrorName } from "../utils/AppError";
+
+// test Organization
+export const organizationTest = async (req: Request, res: Response) => {
+  res.status(200).json({ message: "Organization endpoint works" });
+};
+
+// Create a new Organization
+export const createNewOrganization = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    // const userId = req.userId; // get userId from the request
+    const userId = 3; // NOTE: Placeholder, remove later
+    // Validate the organization data
+    const validatedOrganization = OrganizationCreateSchema.parse(req.body);
+
+    // Create the new organization
+    const newOrganization = await createOrganizationWithDefaults(
+      validatedOrganization,
+      userId,
+    );
+
+    if (newOrganization) {
+      // Organization was created successfully
+      res.status(201).json({
+        message: "Organization created successfully",
+        data: newOrganization,
+      });
+    } else {
+      // createOrganizationWithDefaults returned undefined, something went wrong
+      throw new AppError(
+        AppErrorName.EMPTY_RESULT_ERROR,
+        "Organization creation returned empty result.",
+        500,
+        true,
+      );
+    }
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -6,6 +6,8 @@ import express, { NextFunction, Request, Response } from "express";
 import multer from "multer";
 import path from "path";
 import { errorHandler } from "./middleware/errorHandler";
+import event from "./routes/event.routes";
+import org from "./routes/org.routes";
 import school from "./routes/school.routes";
 import student from "./routes/user.routes";
 import UploadToS3 from "./utils/S3Uploader";
@@ -50,6 +52,8 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 // routes
 app.use("/api", student);
 app.use("/api", school);
+app.use("/api/events", event);
+app.use("/api/orgs", org);
 
 app.get("/Test", (req: Request, res: Response) => {
   console.log("The backend is hit");

--- a/backend/routes/event.routes.ts
+++ b/backend/routes/event.routes.ts
@@ -1,0 +1,32 @@
+import express from "express";
+import {
+  createEvent,
+  createVerifiedEvent,
+  deleteEvent,
+  eventTest,
+  getAllEvents,
+  getAllEventsByOrganization,
+  getAllVerifiedEvents,
+  getEventById,
+  getRecentEvents,
+  updateEvent,
+} from "../controllers/event.controller";
+import { upload } from "../utils/fileUpload";
+
+const router = express.Router();
+
+// app.use(verifyAuthentication); // Use auth middleware for all routes
+
+router.get("/test", eventTest);
+router.get("/", getAllEvents);
+router.get("/verified", getAllVerifiedEvents);
+router.get("/organization/:id", getAllEventsByOrganization);
+router.get("/recent/", getRecentEvents); // with pagination params
+router.get("/:id", getEventById);
+
+router.post("/organization/:id", upload.single("image"), createVerifiedEvent);
+router.post("/", upload.single("image"), createEvent);
+router.patch("/:id", upload.single("image"), updateEvent);
+router.delete("/:id", deleteEvent);
+
+export default router;

--- a/backend/routes/org.routes.ts
+++ b/backend/routes/org.routes.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import {
+  createNewOrganization,
+  organizationTest,
+} from "../controllers/org.controller";
+
+const router = express.Router();
+
+router.get("/test", organizationTest);
+router.post("/", createNewOrganization);
+
+export default router;

--- a/backend/services/org.service.ts
+++ b/backend/services/org.service.ts
@@ -1,0 +1,129 @@
+import {
+  UserRole,
+  Organization,
+  Permission,
+  AppPermissionName,
+} from "@prisma/client";
+import prisma from "../prisma/client";
+import { OrganizationCreateInput } from "../../shared/zodSchemas";
+import { defaultRolePermissions } from "../constants";
+import { AppError, AppErrorName } from "../utils/AppError";
+
+// Creates a new organization and add the default role permissions
+// This messy but it works for now
+export const createOrganizationWithDefaults = async (
+  organizationData: OrganizationCreateInput,
+  userId: number,
+): Promise<Organization | undefined> => {
+  let newOrganization: Organization | undefined;
+
+  // Fetch default permissions from the permission table in database
+  const defaultPermissions = await fetchDefaultPermissions(
+    defaultRolePermissions,
+  );
+
+  // start transaction
+  await prisma.$transaction(async (tx) => {
+    // Create the organization
+    newOrganization = await tx.organization.create({
+      data: {
+        ...organizationData,
+      },
+    });
+
+    const newOrgId = newOrganization.id;
+
+    // Get roleId of the Owner role
+    const roleId = (
+      await tx.role.findFirst({
+        where: {
+          roleName: UserRole.Owner,
+        },
+      })
+    )?.id;
+
+    if (roleId) {
+      // Set the user as the owner of the organization
+      await tx.userOrganizationRole.create({
+        data: {
+          userId,
+          organizationId: newOrganization.id,
+          roleId: roleId,
+        },
+      });
+    } else {
+      throw new AppError(
+        AppErrorName.NOT_FOUND_ERROR,
+        `RoleId for ${UserRole.Owner} not found`,
+        404,
+        true,
+      );
+    }
+
+    // associate default permissions with the newly created organization for each role
+    await Promise.all(
+      // promise.all used to manage concurrency due to the multiple async operations. Here we await the return of all role-related operations
+
+      // iterate over each role and its associated permissions
+      Object.entries(defaultRolePermissions).map(
+        async ([roleName, permissions]) => {
+          // fetch the roleId corresponding to the roleName from db
+          const roleId = (
+            await tx.role.findFirst({
+              // need to use type assertion here so typescript knows its a valid enum key
+              where: {
+                roleName: UserRole[roleName as keyof typeof UserRole],
+              },
+            })
+          )?.id;
+
+          if (roleId && newOrganization) {
+            await Promise.all(
+              // await the return of all permission-related operations for a specific role
+              // iterate over the permissions for the role
+              permissions.map(async (permission) => {
+                // fetch the permissionId corresponding the permission in current iteration
+                const permissionId = defaultPermissions.find(
+                  (p) => p.permissionName === permission,
+                )?.id;
+
+                if (permissionId) {
+                  // create records to associate org with its roles and permissions
+                  await tx.organizationRolePermission.create({
+                    data: {
+                      // organizationId: newOrganization?.id,
+                      organizationId: newOrgId,
+                      roleId,
+                      permissionId,
+                    },
+                  });
+                }
+              }),
+            );
+          }
+        },
+      ),
+    );
+    // log success
+    console.log(
+      `Organization ${newOrganization.id} created with default permissions:`,
+      newOrganization,
+    );
+  }); // end of prisma transaction
+  return newOrganization;
+};
+
+// helper function to get the permission record for each value in rolePermissions
+async function fetchDefaultPermissions(
+  rolePermissions: Record<UserRole, readonly AppPermissionName[]>,
+): Promise<Permission[]> {
+  // call slice() to create shallow copy so we can deal with read only role permissions
+  const allPermissions = Object.values(rolePermissions).flat().slice();
+  return prisma.permission.findMany({
+    where: {
+      permissionName: {
+        in: allPermissions,
+      },
+    },
+  });
+}

--- a/backend/utils/fileUpload.ts
+++ b/backend/utils/fileUpload.ts
@@ -1,6 +1,7 @@
 import { Request } from "express";
 import multer from "multer";
 import path from "path";
+import { AppError, AppErrorName } from "./AppError";
 
 // Configure the file storage
 const storage = multer.diskStorage({
@@ -24,6 +25,9 @@ const storage = multer.diskStorage({
     }
   },
 });
+
+// If we temporarily store uploads in memory buffer instead of saving to disk
+// const storage = multer.memoryStorage();
 
 // Configure file size limits
 const limits = {
@@ -52,7 +56,6 @@ const fileFilter = (req: Request, file: any, cb: any) => {
       cb(null, true);
     } else {
       // reject the file
-      // cb(null, false); // reject without an error
       cb(
         new Error(
           "Invalid file format. Please upload a valid JPEG or PNG file.",
@@ -108,4 +111,22 @@ const convertBytesToSize = (
   ).toString();
 };
 
-export { fileSizeFormatter, upload };
+const generateUniqueFileName = function (fileName: string): string {
+  const maxFilenameSize = 100;
+  const testing = "wow";
+  if (fileName.length > maxFilenameSize) {
+    // const error = new Error("Filename too long");
+    throw new AppError(
+      AppErrorName.FILE_UPLOAD_ERROR,
+      `Error generating unique file name: too long, must be fewer than ${maxFilenameSize} characters`,
+      400,
+      true,
+    );
+  } else {
+    // Generate the filename by adding date string to original name. "2024-01-16T12-34-56.789Z-example.png"
+    const generatedFilename =
+      new Date().toISOString().replace(/:/g, "-") + "_" + fileName;
+    return generatedFilename;
+  }
+};
+export { fileSizeFormatter, generateUniqueFileName, upload };

--- a/shared/zodSchemas.ts
+++ b/shared/zodSchemas.ts
@@ -34,7 +34,6 @@ export const AppPermissionNameSchema = z.enum([
 ///////////////////////////////
 
 export const EventSchema = z.object({
-  status: EventStatusSchema,
   id: z.number().int(),
   userId: z.number().int(),
   organizationId: zodStringToNumberOrNull


### PR DESCRIPTION
**Event controllers:**

- Created basic CRUD controllers (without file upload)
- Can create verified and regular (non verified) events. Verified events are associated with an organization
- Checking user permissions and event ownership currently being done inside controllers
- Added a controller with cursor based pagination for recent events. In the future we can use things like timestamp or id as the cursor, depending on how we want to order the results. I used cursor-based pagination instead of offset pagination because offset pagination does not scale well with db size. Pagination parameters are sent via query params: `?pageSize=<>&cursor=<>`
    example using timestamp as cursor:
      First query, no cursor: `api/events/recent/?pageSize=2`
```javascript
{
  "data": [
  {most recent event data...},
  {2nd most recent event data ...}
  ],
  "cursor": "2024-01-22T21:32:20.539Z"
}
```

Subsequent pages: `api/events/recent/?pageSize=2&cursor=2024-01-22T21:32:20.539Z`

```javascript
{
  "data": [
  {3rd most recent event data...},
  {4th most recent event data...}
  ],
  "cursor": "2024-01-22T21:22:01.911Z"
}
```
   When we reach the end of the available events the cursor is null
```javascript
{
  "data": [],
  "cursor": null
}
```

**Organization Controller with Default Role Permissions**

- Added a 'create organization' controller with Prisma transaction for adding the user as the 'Owner' and adding all of the default roles and permissions into the database. This is a bit rough right now but adequate for testing user permission functionality