### PR TITLE
fix login schema to only validate strings

### DIFF
--- a/shared/zodSchemas.ts
+++ b/shared/zodSchemas.ts
@@ -572,8 +572,8 @@ export const otpVerifySchema = z.object({
 });
 
 export const loginSchema = z.object({
-  email: EmailSchema,
-  password: PasswordSchema,
+  email: z.string(),
+  password: z.string(),
 });
 
 export type loginType = z.infer<typeof loginSchema>;


### PR DESCRIPTION
Revert login schema to only validate fields as strings
