### PR TITLE
Jc/comments

### DIFF
--- a/backend/controllers/org.controller.ts
+++ b/backend/controllers/org.controller.ts
@@ -669,7 +669,7 @@ export const manageNewOrganizationRequest = async (
  *    - If the user is already a member (or some other role) it removes them from the organization.
  *    - Owners cannot leave their own organization.
  */
-export const joinOrganization = async (
+export const toggleJoinOrganization = async (
   req: RequestExtended,
   res: Response,
   next: NextFunction,

--- a/backend/prisma/data.ts
+++ b/backend/prisma/data.ts
@@ -62,6 +62,9 @@ export const ids = {
   postIds: {
     1: "20909dd0-c553-11ee-83fd-6f8d6c450910",
     2: "20909dd1-c553-11ee-83fd-6f8d6c450910",
+    3: "20909dd2-c553-11ee-83fd-6f8d6c450910",
+    4: "20909dd3-c553-11ee-83fd-6f8d6c450910",
+    5: "20909dd4-c553-11ee-83fd-6f8d6c450910",
   },
   itemIds: {
     1: "376a4ee0-e6df-11ee-bd3d-0242ac120002",
@@ -371,8 +374,6 @@ export const posts = [
     expiresAt: "2024-10-10T18:00:00Z",
     type: PostType.LookingFor,
     numberOfSpots: 5,
-
-    // Other post details
   },
   {
     id: ids.postIds[2],
@@ -384,7 +385,42 @@ export const posts = [
     expiresAt: "2024-10-10T19:00:00Z",
     type: PostType.LookingFor,
     numberOfSpots: 8,
-    // Other post details
+  },
+  {
+    id: ids.postIds[3],
+    userId: ids.userIds[4],
+    institutionId: ids.instituteIds[1],
+    title: "Squash partner",
+    description: "Lets play squash at 5pm",
+    createdAt: "2024-11-10T10:00:00Z",
+    expiresAt: "2024-11-10T19:00:00Z",
+    type: PostType.LookingFor,
+    numberOfSpots: 1,
+    numberOfSpotsLeft: 1,
+  },
+  {
+    id: ids.postIds[4],
+    userId: ids.userIds[1],
+    institutionId: ids.instituteIds[1],
+    title: "Casual Chess Match",
+    description:
+      "Looking for 1 person to play chess with between noon and 2:30",
+    createdAt: "2024-11-10T11:00:00Z",
+    expiresAt: "2024-11-10T19:00:00Z",
+    type: PostType.LookingFor,
+    numberOfSpots: 1,
+    numberOfSpotsLeft: 0,
+  },
+  {
+    id: ids.postIds[5],
+    userId: ids.userIds[1],
+    institutionId: ids.instituteIds[1],
+    title: "Found lost headphones in TFDL",
+    description:
+      "I found them on the fourth floor near the elevator. Msg me if you think its yours",
+    createdAt: "2024-10-10T06:00:00Z",
+    expiresAt: "2024-11-10T12:00:00Z",
+    type: PostType.LookingFor,
   },
 ];
 

--- a/backend/prisma/data.ts
+++ b/backend/prisma/data.ts
@@ -76,6 +76,9 @@ export const ids = {
   commentIds: {
     1: "37e11780-c553-11ee-83fd-6f8d6c450910",
     2: "37e11781-c553-11ee-83fd-6f8d6c450910",
+    3: "37e11782-c553-11ee-83fd-6f8d6c450910",
+    4: "37e11783-c553-11ee-83fd-6f8d6c450910",
+    5: "37e11784-c553-11ee-83fd-6f8d6c450910",
   },
   programIds: {
     1: "c5ba3bc0-c5f5-11ee-83fd-6f8d6c450910",
@@ -529,18 +532,39 @@ export const images = [
 
 export const comments = [
   {
+    id: ids.commentIds[1],
     userId: ids.userIds[1],
     postId: ids.postIds[1],
-    text: "This is the first comment!",
+    content: "This is the first comment!",
     createdAt: "2024-10-10T18:00:00Z",
-    // Other post details
   },
   {
+    id: ids.commentIds[2],
+    userId: ids.userIds[2],
+    postId: ids.postIds[1],
+    content: "Cool post",
+    createdAt: "2024-10-10T18:30:00Z",
+  },
+  {
+    id: ids.commentIds[3],
+    userId: ids.userIds[3],
+    postId: ids.postIds[1],
+    content: "Hello!",
+    createdAt: "2024-10-10T18:40:00Z",
+  },
+  {
+    id: ids.commentIds[4],
     userId: ids.userIds[2],
     postId: ids.postIds[2],
-    text: "Another post here!",
+    content: "Another post here!",
     createdAt: "2024-10-10T19:00:00Z",
-    // Other post details
+  },
+  {
+    id: ids.commentIds[5],
+    userId: ids.userIds[1],
+    postId: ids.postIds[2],
+    content: ":D",
+    createdAt: "2024-10-10T19:21:00Z",
   },
 ];
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -99,6 +99,7 @@ model User {
   subscriptions        TopicSubscription[]
   UserOrganizationRole UserOrganizationRole[]
   pushTokens           PushToken[]
+  postAttendances      PostAttendance[]
 
   degreeName String? @map("degree_name")
 
@@ -170,25 +171,26 @@ model UserEventResponse {
 }
 
 model Post {
-  id                String        @id @default(uuid())
-  userId            String        @map("user_id")
-  organizationId    String?       @map("organization_id")
+  id                String           @id @default(uuid())
+  userId            String           @map("user_id")
+  organizationId    String?          @map("organization_id")
   image             String?
-  createdAt         DateTime      @unique @default(now()) @map("created_at")
+  createdAt         DateTime         @unique @default(now()) @map("created_at")
   title             String
   description       String?
-  isPublic          Boolean       @default(true)
-  isFlagged         Boolean       @default(false)
-  expiresAt         DateTime?     @map("expires_at")
-  numberOfSpots     Int?          @map("number_of_spots")
-  numberOfSpotsLeft Int?          @map("number_of_spots_left")
-  user              User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  organization      Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  isPublic          Boolean          @default(true)
+  isFlagged         Boolean          @default(false)
+  expiresAt         DateTime?        @map("expires_at")
+  numberOfSpots     Int?             @map("number_of_spots")
+  numberOfSpotsLeft Int?             @map("number_of_spots_left")
+  user              User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization      Organization?    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   type              PostType
   comments          Comment[]
   postTags          PostTag[]
-  institutionId     String        @map("institution_id")
-  Institution       Institution   @relation(fields: [institutionId], references: [id], onDelete: Cascade)
+  institutionId     String           @map("institution_id")
+  Institution       Institution      @relation(fields: [institutionId], references: [id], onDelete: Cascade)
+  postAttendees     PostAttendance[]
 
   @@index([userId])
   @@index([organizationId])
@@ -214,6 +216,18 @@ model Comment {
   @@index([userId])
   @@index([postId])
   @@map("comment")
+}
+
+model PostAttendance {
+  postId String @map("post_id")
+  userId String @map("user_id")
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  post   Post   @relation(fields: [postId], references: [id], onDelete: Cascade)
+
+  @@id([postId, userId])
+  @@index([userId])
+  @@index([postId])
+  @@map("post_attendance")
 }
 
 model Organization {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -170,31 +170,25 @@ model UserEventResponse {
 }
 
 model Post {
-  id             String  @id @default(uuid())
-  userId         String  @map("user_id")
-  organizationId String? @map("organization_id")
-
-  image       String?
-  createdAt   DateTime  @unique @default(now()) @map("created_at")
-  title       String
-  description String?
-  isPublic    Boolean   @default(true)
-  isFlagged   Boolean   @default(false)
-  expiresAt   DateTime? @map("expires_at")
-
-  numberOfSpots     Int? @map("number_of_spots")
-  numberOfSpotsLeft Int? @map("number_of_spots_left")
-
-  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  organization Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-
-  type PostType
-
-  comments Comment[]
-  postTags PostTag[]
-
-  institutionId String      @map("institution_id")
-  Institution   Institution @relation(fields: [institutionId], references: [id], onDelete: Cascade)
+  id                String        @id @default(uuid())
+  userId            String        @map("user_id")
+  organizationId    String?       @map("organization_id")
+  image             String?
+  createdAt         DateTime      @unique @default(now()) @map("created_at")
+  title             String
+  description       String?
+  isPublic          Boolean       @default(true)
+  isFlagged         Boolean       @default(false)
+  expiresAt         DateTime?     @map("expires_at")
+  numberOfSpots     Int?          @map("number_of_spots")
+  numberOfSpotsLeft Int?          @map("number_of_spots_left")
+  user              User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization      Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  type              PostType
+  comments          Comment[]
+  postTags          PostTag[]
+  institutionId     String        @map("institution_id")
+  Institution       Institution   @relation(fields: [institutionId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@index([organizationId])
@@ -211,10 +205,11 @@ model Comment {
   id        String   @id @default(uuid())
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId    String   @map("user_id")
-  post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
   postId    String   @map("post_id")
+  post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  content   String
   createdAt DateTime @unique @default(now()) @map("created_at")
-  text      String
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   @@index([userId])
   @@index([postId])

--- a/backend/routes/org.routes.ts
+++ b/backend/routes/org.routes.ts
@@ -11,7 +11,7 @@ import {
   organizationTest,
   updateOrganization,
   manageNewOrganizationRequest,
-  joinOrganization,
+  toggleJoinOrganization,
   deleteOrganizationProfileImage,
   uploadOrgProfilePic,
 } from "../controllers/org.controller";
@@ -32,7 +32,7 @@ router.get("/:id/pendingUsers", getAllPendingOrgUsers);
 router.get("/pending", getAllPendingOrganizations); // for admin interface
 router.post("/:id/orgApproval", manageNewOrganizationRequest); // for admin interface
 router.post("/:id/membership/approval", manageMembershipRequest);
-router.post("/join/:id", joinOrganization);
+router.post("/join/:id", toggleJoinOrganization);
 router.post("/", upload.single("file"), createNewOrganization);
 router.get("/:id", getOrganizationById);
 router.patch("/:id", upload.single("file"), updateOrganization);

--- a/backend/routes/post.routes.ts
+++ b/backend/routes/post.routes.ts
@@ -10,6 +10,7 @@ import {
   createPostComment,
   updatePostComment,
   deletePostComment,
+  toggleJoinLookingFor,
 } from "../controllers/post.controller";
 import { upload } from "../utils/S3Uploader";
 import { verifyAuthentication } from "../middleware/verifyAuth";
@@ -21,6 +22,7 @@ router.use(verifyAuthentication); // Use auth middleware for all routes below
 router.get("/", getAllPosts);
 router.post("/", createLookingForPost);
 router.get("/:id", getPostById);
+router.post("/:id/toggleAttendance", toggleJoinLookingFor);
 router.get("/:id/comments/", getPostCommentsById);
 router.post("/:id/comments/", createPostComment);
 router.patch("/:postId/comments/:commentId", updatePostComment);

--- a/backend/routes/post.routes.ts
+++ b/backend/routes/post.routes.ts
@@ -7,6 +7,9 @@ import {
   createLookingForPost,
   getPostById,
   getPostCommentsById,
+  createPostComment,
+  updatePostComment,
+  deletePostComment,
 } from "../controllers/post.controller";
 import { upload } from "../utils/S3Uploader";
 import { verifyAuthentication } from "../middleware/verifyAuth";
@@ -18,7 +21,13 @@ router.use(verifyAuthentication); // Use auth middleware for all routes below
 router.get("/", getAllPosts);
 router.post("/", createLookingForPost);
 router.get("/:id", getPostById);
-router.get("/comments/:id", getPostCommentsById);
+router.get("/:id/comments/", getPostCommentsById);
+router.post("/:id/comments/", createPostComment);
+router.patch("/:postId/comments/:commentId", updatePostComment);
+router.delete("/:postId/comments/:commentId", deletePostComment);
 router.patch("/:id", upload.single("file"), updatePost);
 router.delete("/:id", deletePost);
 export default router;
+
+// make sure delete post still works
+// test get, create, update, delete

--- a/backend/services/post.service.ts
+++ b/backend/services/post.service.ts
@@ -1,0 +1,126 @@
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+import prisma from "../prisma/client";
+import { AppError, AppErrorName } from "../utils/AppError";
+import { Post, PostAttendance } from "@prisma/client";
+
+export async function addPostAttendance(userId: string, post: Post) {
+  try {
+    // Check if the post cannot be joined
+    if (post.numberOfSpots && !post.numberOfSpotsLeft) {
+      throw new AppError(
+        AppErrorName.NO_SPOT_AVAILABLE_ERROR,
+        `This post has no available spots to join`,
+        400,
+        true,
+      );
+    }
+    if (!post.numberOfSpots) {
+      throw new AppError(
+        AppErrorName.NO_SPOT_AVAILABLE_ERROR,
+        `This post cannot be joined`,
+        400,
+        true,
+      );
+    }
+
+    let newAttendance: PostAttendance | undefined;
+    // start a transaction
+    await prisma.$transaction(async (tx) => {
+      // add the user's attendance
+      newAttendance = await prisma.postAttendance.create({
+        data: {
+          postId: post.id,
+          userId,
+        },
+      });
+
+      // decrement number of spots available
+      await prisma.post.update({
+        where: { id: post.id },
+        data: {
+          numberOfSpotsLeft: { increment: -1 },
+        },
+      });
+    });
+
+    if (!newAttendance) {
+      throw new AppError(
+        AppErrorName.INTERNAL_SERVER_ERROR,
+        `Failed to add user attendance`,
+        500,
+        true,
+      );
+    }
+
+    return newAttendance;
+  } catch (error: any) {
+    if (error instanceof AppError) {
+      // rethrow error
+      throw error;
+    } else if (
+      error instanceof PrismaClientKnownRequestError &&
+      error.code == "P2002" // unique constraint violation error code
+    ) {
+      throw new AppError(
+        AppErrorName.RECORD_EXISTS_ERROR,
+        "User is already attending",
+        400,
+        true,
+      );
+    } else {
+      throw new AppError(
+        AppErrorName.INTERNAL_SERVER_ERROR,
+        "An unexpected error occurred adding user attendence",
+        500,
+        true,
+      );
+    }
+  }
+}
+
+export async function removePostAttendance(userId: string, post: Post) {
+  try {
+    // check if post has attendance fields
+    if (!post.numberOfSpots) {
+      throw new AppError(
+        AppErrorName.NO_SPOT_AVAILABLE_ERROR,
+        `This post does not have attendance`,
+        400,
+        true,
+      );
+    }
+
+    // start a transaction
+    await prisma.$transaction(async (tx) => {
+      // remove the user's attendence
+      await prisma.postAttendance.delete({
+        where: {
+          postId_userId: {
+            postId: post.id,
+            userId,
+          },
+        },
+      });
+
+      // Increment number of spots available
+      await prisma.post.update({
+        where: { id: post.id },
+        data: {
+          numberOfSpotsLeft: { increment: 1 },
+        },
+      });
+    });
+  } catch (error: any) {
+    if (error instanceof AppError) {
+      // rethrow error
+      throw error;
+    } else {
+      throw new AppError(
+        AppErrorName.INTERNAL_SERVER_ERROR,
+        "An unexpected error occurred removing user attendence",
+        500,
+        true,
+      );
+    }
+  }
+}

--- a/backend/utils/AppError.ts
+++ b/backend/utils/AppError.ts
@@ -46,6 +46,7 @@ enum AppErrorName {
   DATABASE_ERROR = "DatabaseError",
   PRISMA_ERROR = "PrismaError",
   INTERNAL_SERVER_ERROR = "InternalServerError",
+  NO_SPOT_AVAILABLE_ERROR = "NoSpotsAvailableError",
 }
 
 export { AppError, AppErrorName };

--- a/frontend/src/lib/apiFunctions/LookingFor.ts
+++ b/frontend/src/lib/apiFunctions/LookingFor.ts
@@ -15,7 +15,7 @@ export const getLookingForById = async (id: string) => {
 export const getLookingForCommentsById = async (id: string) => {
   try {
     return (
-      await CBRequest("GET", `/api/post/comments/:id`, {
+      await CBRequest("GET", `/api/post/:id/comments`, {
         params: { id },
       })
     ).data;

--- a/frontend/src/lib/requestHelpers.ts
+++ b/frontend/src/lib/requestHelpers.ts
@@ -155,7 +155,7 @@ const allowedEndpoints = [
   "/api/item/",
   "/api/item/:id",
   "/api/post/:id",
-  "/api/post/comments/:id",
+  "/api/post/:id/comments",
 
   // profile related endpoints
   "/api/profile/saved",
@@ -197,7 +197,7 @@ export type IdRequiredEndPoints =
   | "/api/profile/posts/:id"
   | "/api/item/:id"
   | "/api/post/:id"
-  | "/api/post/comments/:id"
+  | "/api/post/:id/comments"
   | "/api/orgs/deleteProfilePicture/:id"
   | "/api/orgs/profilePicture/:id"
   | "/api/profile/orgItems/:id"

--- a/shared/zodSchemas.ts
+++ b/shared/zodSchemas.ts
@@ -386,10 +386,20 @@ export const CommentSchema = z.object({
   userId: z.string().uuid(),
   postId: z.string().uuid(),
   createdAt: z.coerce.date(),
-  text: z.string(),
+  updatedAt: z.coerce.date(),
+  content: z.string({
+    required_error: "Comment message is required",
+    invalid_type_error: "Invalid comment input",
+  }),
 });
 
 export type Comment = z.infer<typeof CommentSchema>;
+
+export const CommentCreateSchema = CommentSchema.pick({
+  content: true,
+});
+
+export type CommentCreateType = z.infer<typeof CommentCreateSchema>;
 
 /////////////////////////////////////////
 // USER ORGANIZATION ROLE SCHEMAS
@@ -516,19 +526,26 @@ export type TopicSubscription = z.infer<typeof TopicSubscriptionSchema>;
 // UTILITY SCHEMAS
 ///////////////////////////////
 
+export const IdSchema = z.coerce
+  .string()
+  .uuid()
+  .refine((data) => data.length > 0, {
+    message: "ID is invalid",
+  });
+
 // Schema for validating an ID integer parameter
 export const IdParamSchema = z.object({
-  id: z.coerce
-    .string()
-    .uuid()
-    .refine((data) => data.length > 0, {
-      message: "ID is invalid",
-    }),
+  id: IdSchema,
 });
 
 export const OrganizationRoleNameParamsSchema = z.object({
   organizationId: z.string().uuid(),
   roleName: UserRoleSchema,
+});
+
+export const CommentParamsSchema = z.object({
+  postId: IdSchema,
+  commentId: IdSchema,
 });
 
 ///////////////////////////////


### PR DESCRIPTION
**Added CRUD functionality for Post comments**
- Users can make top level comments on posts

**Created an endpoint for toggling a User's attendance on a Post** 
- We can hit the same endpoint to toggle the user's attendance if attendance is permitted on the post
- added a PostAttendance table to prisma schema to keep track of attending users

**Misc**: 
- renamed the "text" field of comment to "content"
- renamed the `joinOrganization()` controller to `toggleJoinOrganization()`
- Modified the position of the `/:id`  param in the getPostCommentsById route for consistency
- The Post model in schema.prisma was formatted for readability with `npx prisma format` . The only actual change is the addition of postAttendees[]
